### PR TITLE
Поддержка Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^v8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^v8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.15"


### PR DESCRIPTION
Расширены ограничения `illuminate/contracts` и `illuminate/support` до `^13.0`, чтобы пакет можно было устанавливать в приложениях на Laravel 13.

Проверка: `composer update` успешно разрешает зависимости с illuminate 13.x при PHP 8.3+.

Made with [Cursor](https://cursor.com)